### PR TITLE
Curated and custom list of mods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 Made with [VouDoo](https://github.com/VouDoo) :wrench:
 
-This PowerShell script installs various mods for LethalCompany. It also includes the installation of BepInEx, a game patcher / plugin framework for Unity.
+This PowerShell script installs a list of selected mods for LethalCompany.
 
-List of mods installed by the script:
+It also includes the installation of BepInEx, a game patcher / plugin framework for Unity.
+
+## Curated list of mods
+
+### `default` mods
+
+_This is the list of mods to be installed when no curated or custom list is specified by the user._
 
 - [MoreCompany](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) by [notnotnotswipez](https://github.com/notnotnotswipez)
 - [LateCompany](https://thunderstore.io/c/lethal-company/p/anormaltwig/LateCompany/) by [anormaltwig](https://github.com/ANormalTwig)

--- a/mods/default.json
+++ b/mods/default.json
@@ -1,0 +1,51 @@
+[
+  {
+    "Name": "MoreCompany",
+    "Type": "BepInExPlugin",
+    "Namespace": "notnotnotswipez",
+    "Description": "Increase the max player count",
+    "From": "Thunderstore"
+  },
+  {
+    "Name": "LateCompany",
+    "Type": "BepInExPlugin",
+    "Namespace": "anormaltwig",
+    "Description": "Players can join after the game has started",
+    "From": "Thunderstore"
+  },
+  {
+    "Name": "ShipLoot",
+    "Type": "BepInExPlugin",
+    "Namespace": "tinyhoot",
+    "Description": "Display the total scrap value on the ship",
+    "From": "Thunderstore"
+  },
+  {
+    "Name": "Solos_Bodycams",
+    "Type": "BepInExPlugin",
+    "Namespace": "CapyCat",
+    "Description": "Replace the ships internal camera (right monitor) with bodycams that are linked to the radar",
+    "From": "Thunderstore"
+  },
+  {
+    "Name": "TerminalApi",
+    "Type": "BepInExPlugin",
+    "Namespace": "NotAtomicBomb",
+    "Description": "Provides a nice a easy way to add and modify terminal keywords",
+    "From": "Thunderstore"
+  },
+  {
+    "Name": "Terminal_Clock",
+    "Type": "BepInExPlugin",
+    "Namespace": "NotAtomicBomb",
+    "Description": "Add a clock to the top right of the terminal",
+    "From": "Thunderstore"
+  },
+  {
+    "Name": "LBtoKG",
+    "Type": "BepInExPlugin",
+    "Namespace": "Zduniusz",
+    "Description": "View items weight in kilograms",
+    "From": "Thunderstore"
+  }
+]


### PR DESCRIPTION
The user can now:

- Specify, with the `List` parameter, the name of a curated list of mods, which is located in the repo under `mods/<listname>.json`
- Or, pass the path to a custom file including a custom list of mods with the `File` parameter.

If no parameter is passed, the script uses the `List` parameter with default value as `default`.

Added `mods/default.json` file, which is the `default` curated list of mods maintained by us.